### PR TITLE
Add ability to customize Provider function name

### DIFF
--- a/schemas-extractor/build-providers.sh
+++ b/schemas-extractor/build-providers.sh
@@ -32,6 +32,7 @@ function process_provider() {
   repository="$(jq_get "$name" 'repository')"
   pkg_name="$(jq_get "$name" 'pkg_name')"
   provider_args="$(jq_get "$name" 'provider_args')"
+  provider_func_name="$(jq_get "$name" 'provider_func_name')"
   use_master="$(jq_get "$name" 'use_master')"
   go_envs="$(jq_get "$name" 'go_envs')"
   go_args=""
@@ -141,6 +142,7 @@ EOF
     -e "s~__PKG_NAME__~${pkg_name}~g" \
     -e "s~__REVISION__~$revision~g" \
     -e "s~__PROVIDER_ARGS__~$provider_args~g" \
+    -e "s~__PROVIDER_FUNC_NAME__~$provider_func_name~g" \
     -e "s~__SDK__~$sdk~g" \
     -e "s~__OUT__~$out~g" \
     "$CUR/template/$base_file" \

--- a/schemas-extractor/providers.base.json
+++ b/schemas-extractor/providers.base.json
@@ -5,7 +5,8 @@
     "file": "__NAME__.json",
     "pkg_name": "__NAME__",
     "go_envs": "GO111MODULE=off",
-    "provider_args": ""
+    "provider_args": "",
+    "provider_func_name": "Provider"
   },
 
   "scaffolding": {
@@ -37,7 +38,10 @@
   "azure-classic": {
     "skip_generation": true
   },
-  "azuread": {},
+  "azuread": {
+    "provider_func_name": "AzureADProvider",
+    "pkg_name": "internal/provider"
+  },
   "azuredevops": {
     "repository": "github.com/microsoft/terraform-provider-__NAME__"
   },

--- a/schemas-extractor/providers.base.json
+++ b/schemas-extractor/providers.base.json
@@ -45,7 +45,10 @@
   "azuredevops": {
     "repository": "github.com/microsoft/terraform-provider-__NAME__"
   },
-  "azurerm": {},
+  "azurerm": {
+    "provider_func_name": "AzureProvider",
+    "pkg_name": "internal/provider"
+  },
   "azurestack": {},
   "baiducloud": {},
   "bigip": {},

--- a/schemas-extractor/template/provider/terraform-plugin-sdk-v1/generate-schema.go
+++ b/schemas-extractor/template/provider/terraform-plugin-sdk-v1/generate-schema.go
@@ -296,7 +296,7 @@ type ResourceProviderSchema struct {
 func main() {
 	var provider tf.ResourceProvider
 	//noinspection GoUnresolvedReference
-	provider = prvdr.Provider(__PROVIDER_ARGS__)
+	provider = prvdr.__PROVIDER_FUNC_NAME__(__PROVIDER_ARGS__)
 	Generate(provider.(*schema.Provider), "__NAME__", "__OUT__")
 }
 

--- a/schemas-extractor/template/provider/terraform-plugin-sdk-v2/generate-schema.go
+++ b/schemas-extractor/template/provider/terraform-plugin-sdk-v2/generate-schema.go
@@ -295,7 +295,7 @@ type ResourceProviderSchema struct {
 func main() {
 	var provider *schema.Provider
 	//noinspection GoUnresolvedReference
-	provider = prvdr.Provider(__PROVIDER_ARGS__)
+	provider = prvdr.__PROVIDER_FUNC_NAME__(__PROVIDER_ARGS__)
 	Generate(provider, "__NAME__", "__OUT__")
 }
 

--- a/schemas-extractor/template/provider/terraform/generate-schema.go
+++ b/schemas-extractor/template/provider/terraform/generate-schema.go
@@ -273,7 +273,7 @@ type ResourceProviderSchema struct {
 func main() {
 	var provider tf.ResourceProvider
 	//noinspection GoUnresolvedReference
-	provider = prvdr.Provider(__PROVIDER_ARGS__)
+	provider = prvdr.__PROVIDER_FUNC_NAME__(__PROVIDER_ARGS__)
 	Generate(provider.(*schema.Provider), "__NAME__", "__OUT__")
 }
 


### PR DESCRIPTION
This adds the ability to define a custom function name to be used when loading a provider. In this case, AzureAD and AzureRM do this as shown below:

Provider Function: AzureADProvider
https://github.com/hashicorp/terraform-provider-azuread/blob/848eff9a39de301a5de2cd6a15b30a3985052299/internal/provider/provider.go#L37

Provider Function: AzureProvider
https://github.com/hashicorp/terraform-provider-azurerm/blob/291780012c30d974c87c1ed3d7f9a16257a02c84/internal/provider/provider.go#L21

This should resolve the issue discussed in https://github.com/VladRassokhin/terraform-metadata/issues/14